### PR TITLE
49 default config path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ TESTS = unit-tests/tests-build
 
 ##### BUILDING RULES #####
 
-all: $(NAME)
+all: $(NAME) default-config
 
 $(NAME): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) -o $(NAME)
@@ -61,6 +61,14 @@ re: fclean all
 
 .cpp.o:
 	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+CONFIG_FILE = default.conf
+DEST_DIR = $(HOME)/w3b53rb3ru5
+DEST_FILE = $(DEST_DIR)/w3b53rb3ru5.conf
+
+default-config:
+	@mkdir -p $(DEST_DIR)
+	@sed 's|~|$(HOME)|g' $(CONFIG_FILE) > $(DEST_FILE)
 
 ##### TESTING RULES #####
 

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,11 @@
+server {
+	port		4242
+	server_name	localhost
+	body_size	1K
+	
+	location / {
+		root		~/w3b53rb3ru5/www
+		autoindex	on
+		index		index.html
+	}
+}

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,17 +1,22 @@
 #include "Server/Server.hpp"
 #include <exception>
 #include <iostream>
-
-#define DEFAULT_CONFIG "/etc/w3b53rb3ru5/w3b53rb3ru5.conf"
+#include <cstdlib>
 
 int	main(int argc, char *argv[]) {
 	std::string	conf_path;
+	std::string home_path;
 
 	if (argc == 1) {
-		std::cout << "Warning: Config file missing.\n";
-		std::cout << "Running webserver with default config file: " << DEFAULT_CONFIG << std::endl;
-		conf_path = DEFAULT_CONFIG;
-	}
+        home_path = getenv("HOME");
+        if (home_path.empty()) {
+            std::cerr << "Error: HOME environment variable not set." << std::endl;
+            return (1);
+        }
+        conf_path = home_path + "/w3b53rb3ru5/w3b53rb3ru5.conf";
+        std::cout << "Warning: Config file missing.\n";
+        std::cout << "Running webserver with default config file: " << conf_path << std::endl;
+    }
 	else if (argc > 2) {
 		std::cerr << "Invalid cmd line argument, please run the progam ";
 		std::cerr << "like this: './webserver <config_file_path>'" << std::endl;


### PR DESCRIPTION
I wasn't comfortable with the idea of setting a default path for the config file if the file could not exist yet, so I created a make command to create it.

> Possible bug: while creating the default file I had problems using `~` to represent the home directory. I guess out code doesn't understand `~`. I did a trick with `sed` in the make command as a quickfix just for the default config file.